### PR TITLE
Remove oraclejdk7 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 sudo: false
 jdk:
 - oraclejdk8
-- oraclejdk7
 - openjdk7
 after_script:
 - "./gradlew build"


### PR DESCRIPTION
Remove oraclejdk7 from .travis.yml as Travis does not support it anymore 

Details: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879